### PR TITLE
Add support for snowflake roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ module "sf_loader" {
   snowflake_schema             = "<SCHEMA>"
   snowflake_region             = "<REGION>"
   snowflake_account            = "<ACCOUNT>"
+  snowflake_role               = "<ROLE>"
   snowflake_aws_s3_bucket_name = module.s3_pipeline_bucket.id
 
   ssh_key_name     = "your-key-name"
@@ -168,6 +169,7 @@ module "sf_loader" {
 | <a name="input_snowflake_database"></a> [snowflake\_database](#input\_snowflake\_database) | Snowflake database name | `string` | n/a | yes |
 | <a name="input_snowflake_loader_user"></a> [snowflake\_loader\_user](#input\_snowflake\_loader\_user) | Snowflake username used by loader to perform loading | `string` | n/a | yes |
 | <a name="input_snowflake_password"></a> [snowflake\_password](#input\_snowflake\_password) | Password for snowflake\_loader\_user used by loader to perform loading | `string` | n/a | yes |
+| <a name="input_snowflake_role"></a> [snowflake\_role](#input\_snowflake\_role) | Snowflake role | `string` | null | no |
 | <a name="input_snowflake_region"></a> [snowflake\_region](#input\_snowflake\_region) | Snowflake region | `string` | n/a | yes |
 | <a name="input_snowflake_schema"></a> [snowflake\_schema](#input\_snowflake\_schema) | Snowflake schema name | `string` | n/a | yes |
 | <a name="input_snowflake_warehouse"></a> [snowflake\_warehouse](#input\_snowflake\_warehouse) | Snowflake warehouse name | `string` | n/a | yes |

--- a/main.tf
+++ b/main.tf
@@ -314,6 +314,7 @@ locals {
     sf_password                          = var.snowflake_password
     sf_region                            = var.snowflake_region
     sf_account                           = var.snowflake_account
+    sf_role                              = var.snowflake_role
     sf_wh_name                           = var.snowflake_warehouse
     sf_db_name                           = var.snowflake_database
     sf_schema                            = var.snowflake_schema

--- a/templates/config.json.tmpl
+++ b/templates/config.json.tmpl
@@ -25,6 +25,10 @@
     "warehouse": "${sf_wh_name}",
     # DB schema
     "schema": "${sf_schema}",
+%{ if sf_role != null ~}
+    # DB role
+    "role": "${sf_role}",
+%{ endif ~}
     # DB name
     "database": "${sf_db_name}",
 

--- a/variables.tf
+++ b/variables.tf
@@ -346,6 +346,12 @@ variable "snowflake_account" {
   type        = string
 }
 
+variable "snowflake_role" {
+  description = "Snowflake role"
+  type        = string
+  default     = null
+}
+
 variable "snowflake_aws_s3_bucket_name" {
   description = "AWS bucket name where data to load is stored"
   type        = string


### PR DESCRIPTION
This PR adds support for configuring the role to assume in SnowFlake.
If not set, `"role"` will simply not be added to the generated configuration file, so it should be backwards compatible.